### PR TITLE
Upgrade to Java 21 (Spring Boot 3 / jakarta migration)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TZ="America/Los_Angeles"
 ####
 ## build container
 
-FROM maven:3.9-eclipse-temurin-11 AS build
+FROM maven:3.9-eclipse-temurin-21 AS build
 
 WORKDIR /opt/conciliator
 
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.m2 \
 ####
 ## application container
 
-FROM eclipse-temurin:11
+FROM eclipse-temurin:21
 
 ARG TZ
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,20 +16,24 @@
 
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
+    <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.3</version>
+        <version>3.3.13</version>
     </parent>
 
     <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,7 +55,7 @@
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-            <version>3.9.9</version>
+      <classifier>jakarta</classifier>
         </dependency>
     </dependencies>
 
@@ -60,9 +64,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <release>11</release>
+          <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -101,7 +105,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/src/main/java/com/codefork/refine/Application.java
+++ b/src/main/java/com/codefork/refine/Application.java
@@ -15,6 +15,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -24,6 +25,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+@Configuration
 @SpringBootApplication
 @EnableCaching
 @EnableWebSecurity
@@ -43,7 +45,7 @@ public class Application {
         MemSize memSize = MemSize.valueOf(config.getProperties().getProperty(Config.PROP_CACHE_SIZE));
 
         LogFactory.getLog(getClass()).info(
-                String.format("Initializing cache TTL=%d secs, size=%d %s",
+                "Initializing cache TTL=%d secs, size=%d %s".formatted(
                         ttl, memSize.getSize(), memSize.getUnit().toString()));
 
         org.ehcache.config.CacheConfiguration<Object, Object> cacheConfiguration = CacheConfigurationBuilder
@@ -90,11 +92,10 @@ public class Application {
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .csrf().disable()
-                .authorizeRequests()
-                .anyRequest()
-                .permitAll()
-                .and().build();
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(requests -> requests
+                        .anyRequest()
+                        .permitAll()).build();
     }
 
 }

--- a/src/main/java/com/codefork/refine/controllers/PreviewAPI.java
+++ b/src/main/java/com/codefork/refine/controllers/PreviewAPI.java
@@ -18,7 +18,7 @@ public interface PreviewAPI {
     @RequestMapping(value = { PATH_PREVIEW }, params = "id")
     default Object preview() throws ServiceNotImplementedException {
         throw new ServiceNotImplementedException(
-                String.format("Preview API not implemented for %s data source",
+                "Preview API not implemented for %s data source".formatted(
                         getDataSource().getName()));
     }
 

--- a/src/main/java/com/codefork/refine/controllers/ReconciliationAPI.java
+++ b/src/main/java/com/codefork/refine/controllers/ReconciliationAPI.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 public interface ReconciliationAPI {

--- a/src/main/java/com/codefork/refine/controllers/StatsController.java
+++ b/src/main/java/com/codefork/refine/controllers/StatsController.java
@@ -4,7 +4,6 @@ import com.codefork.refine.datasource.DataSource;
 import com.codefork.refine.datasource.stats.Interval;
 import com.codefork.refine.resources.StatsDataSource;
 import com.codefork.refine.resources.StatsReport;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -23,7 +22,6 @@ public class StatsController {
 
     List<DataSource> dataSources;
 
-    @Autowired
     public StatsController(List<DataSource> dataSources) {
         this.dataSources = dataSources;
     }

--- a/src/main/java/com/codefork/refine/controllers/SuggestAPI.java
+++ b/src/main/java/com/codefork/refine/controllers/SuggestAPI.java
@@ -17,7 +17,7 @@ public  interface SuggestAPI {
     @ResponseBody
     default Object suggestEntity() throws ServiceNotImplementedException {
         throw new ServiceNotImplementedException(
-                String.format("suggest entity service not implemented for %s data source",
+                "suggest entity service not implemented for %s data source".formatted(
                         getDataSource().getName()));
     }
 
@@ -25,7 +25,7 @@ public  interface SuggestAPI {
     @ResponseBody
     default Object suggestProperty() throws ServiceNotImplementedException {
         throw new ServiceNotImplementedException(
-                String.format("suggest property service not implemented for %s data source",
+                "suggest property service not implemented for %s data source".formatted(
                         getDataSource().getName()));
     }
 
@@ -33,7 +33,7 @@ public  interface SuggestAPI {
     @ResponseBody
     default Object suggestType() throws ServiceNotImplementedException {
         throw new ServiceNotImplementedException(
-                String.format("suggest type service not implemented for %s data source",
+                "suggest type service not implemented for %s data source".formatted(
                         getDataSource().getName()));
     }
 

--- a/src/main/java/com/codefork/refine/datasource/DataSource.java
+++ b/src/main/java/com/codefork/refine/datasource/DataSource.java
@@ -18,13 +18,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import javax.annotation.PreDestroy;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.annotation.PreDestroy;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,7 +63,6 @@ public abstract class DataSource {
         }
     };
 
-    @Autowired
     public DataSource(Config config, Stats stats) {
         setConfig(config);
 
@@ -188,7 +186,7 @@ public abstract class DataSource {
 
             Map<String, SearchResponse> resultsMap = search(queriesMap);
 
-            log.debug(String.format("response=%s", new DeferredJSON(resultsMap)));
+            log.debug("response=%s".formatted(new DeferredJSON(resultsMap)));
 
             return resultsMap;
         } catch (JsonProcessingException jse) {
@@ -200,7 +198,7 @@ public abstract class DataSource {
     public ProposePropertiesResponse proposeProperties(String type, int limit)
             throws ServiceNotImplementedException {
         throw new ServiceNotImplementedException(
-                String.format("propose properties service not implemented for %s data source",
+                "propose properties service not implemented for %s data source".formatted(
                         getName()));
     }
 
@@ -224,7 +222,7 @@ public abstract class DataSource {
         response.setMeta(meta);
         response.setRows(rows);
 
-        log.debug(String.format("response=%s", new DeferredJSON(response)));
+        log.debug("response=%s".formatted(new DeferredJSON(response)));
 
         return response;
     }
@@ -238,7 +236,7 @@ public abstract class DataSource {
      */
     public CellList extend(String id, List<PropertyValueIdAndSettings> idsAndSettings) throws ServiceNotImplementedException {
         throw new ServiceNotImplementedException(
-                String.format("extend service not implemented for %s data source",
+                "extend service not implemented for %s data source".formatted(
                         getName()));
     }
 

--- a/src/main/java/com/codefork/refine/datasource/WebServiceDataSource.java
+++ b/src/main/java/com/codefork/refine/datasource/WebServiceDataSource.java
@@ -190,7 +190,7 @@ public abstract class WebServiceDataSource extends DataSource {
             }
         }
 
-        log.debug(String.format("%s tasks finished in %s (thread pool size=%s)", queryEntries.size(), System.currentTimeMillis() - start, getThreadPool().getPoolSize()));
+        log.debug("%s tasks finished in %s (thread pool size=%s)".formatted(queryEntries.size(), System.currentTimeMillis() - start, getThreadPool().getPoolSize()));
 
         return allResults;
     }
@@ -225,7 +225,7 @@ public abstract class WebServiceDataSource extends DataSource {
         try {
             long start = System.currentTimeMillis();
             updateStats(results.values());
-            log.debug(String.format("updateStats took %s ms", System.currentTimeMillis() - start));
+            log.debug("updateStats took %s ms".formatted(System.currentTimeMillis() - start));
         } catch(Exception e) {
             log.error("error in updateStats(), ignoring and continuing: " + StringUtil.getStackTrace(e));
         }

--- a/src/main/java/com/codefork/refine/datasource/WebServiceSearchTask.java
+++ b/src/main/java/com/codefork/refine/datasource/WebServiceSearchTask.java
@@ -44,7 +44,7 @@ public class WebServiceSearchTask implements SearchTask {
         try {
             results = dataSource.searchCheckCache(searchQuery);
         } catch (Exception e) {
-            dataSource.getLog().error(String.format("error for query=%s", searchQuery.getQuery()), e);
+            dataSource.getLog().error("error for query=%s".formatted(searchQuery.getQuery()), e);
             if (e.toString().contains("HTTP response code: 429")) {
                 return new SearchResult(key, SearchResult.ErrorType.TOO_MANY_REQUESTS);
             }

--- a/src/main/java/com/codefork/refine/datasource/stats/Stats.java
+++ b/src/main/java/com/codefork/refine/datasource/stats/Stats.java
@@ -54,8 +54,8 @@ public class Stats {
         buckets.add(new Bucket("Last day", 24 * 60 * 60));
         buckets.add(new Bucket("Last week", 7 * 24 * 60 * 60));
 
-        log.debug(String.format("Initialized Stats, max number of intervals stored should be %s",
-                buckets.get(buckets.size()-1).getSize() / intervalSize));
+        log.debug("Initialized Stats, max number of intervals stored should be %s".formatted(
+                buckets.get(buckets.size() - 1).getSize() / intervalSize));
     }
 
     public String getDataSourceName() {
@@ -130,7 +130,7 @@ public class Stats {
                 interval = getFirstInterval();
             }
         }
-        log.debug(String.format("Removed %s intervals from stats history, took %s ms",
+        log.debug("Removed %s intervals from stats history, took %s ms".formatted(
                 intervalsSizeStart - intervals.size(), System.currentTimeMillis() - start));
     }
 

--- a/src/main/java/com/codefork/refine/openlibrary/OpenLibrary.java
+++ b/src/main/java/com/codefork/refine/openlibrary/OpenLibrary.java
@@ -13,7 +13,6 @@ import com.codefork.refine.resources.Result;
 import com.codefork.refine.resources.ServiceMetaDataResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
@@ -29,7 +28,6 @@ public class OpenLibrary extends WebServiceDataSource {
     private final ObjectMapper mapper = new ObjectMapper();
     private static final NameType bookType = new NameType("/book/book", "Book");
 
-    @Autowired
     public OpenLibrary(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
 

--- a/src/main/java/com/codefork/refine/orcid/Orcid.java
+++ b/src/main/java/com/codefork/refine/orcid/Orcid.java
@@ -6,7 +6,6 @@ import com.codefork.refine.ThreadPoolFactory;
 import com.codefork.refine.datasource.ConnectionFactory;
 import com.codefork.refine.datasource.stats.Stats;
 import com.codefork.refine.resources.Result;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +14,6 @@ import java.util.List;
 @Component("orcid")
 public class Orcid extends OrcidBase {
 
-    @Autowired
     public Orcid(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
     }

--- a/src/main/java/com/codefork/refine/orcid/OrcidBase.java
+++ b/src/main/java/com/codefork/refine/orcid/OrcidBase.java
@@ -13,7 +13,6 @@ import com.codefork.refine.resources.Result;
 import com.codefork.refine.resources.ServiceMetaDataResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.web.util.UriUtils;
 
@@ -44,7 +43,6 @@ public abstract class OrcidBase extends WebServiceDataSource {
 
     private static final int POOL_SIZE_FOR_INDIVIDUAL_RECORDS = 20;
 
-    @Autowired
     public OrcidBase(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
         threadPoolForIndividualRecords = createThreadPoolForIndividualRecords();
@@ -115,7 +113,7 @@ public abstract class OrcidBase extends WebServiceDataSource {
 
     protected List<Result> searchKeyword(SearchQuery query) throws Exception {
         String q = createQueryString(query);
-        String url = String.format("https://pub.orcid.org/v2.1/search/?rows=%d&q=", query.getLimit()) +
+        String url = "https://pub.orcid.org/v2.1/search/?rows=%d&q=".formatted(query.getLimit()) +
                 UriUtils.encodeQueryParam(q, "UTF-8");
         return doSearch(query, url);
     }
@@ -140,7 +138,7 @@ public abstract class OrcidBase extends WebServiceDataSource {
             log.error("Ignoring error from trying to close input stream and connection: " + ioe);
         }
 
-        log.debug(String.format("Query: %s - parsing took %dms, got %d results",
+        log.debug("Query: %s - parsing took %dms, got %d results".formatted(
                 query.getQuery(), parseTime, orcidParser.getResults().size()));
 
         return fillInResults(query, orcidParser.getResults());
@@ -158,7 +156,7 @@ public abstract class OrcidBase extends WebServiceDataSource {
 
         @Override
         public Result call() throws Exception {
-            String url = String.format("https://pub.orcid.org/v2.1/%s/record", result.getId());
+            String url = "https://pub.orcid.org/v2.1/%s/record".formatted(result.getId());
 
             log.debug("Filling in ORCID result: making request to " + url);
 

--- a/src/main/java/com/codefork/refine/orcid/OrcidSmartNames.java
+++ b/src/main/java/com/codefork/refine/orcid/OrcidSmartNames.java
@@ -9,7 +9,6 @@ import com.codefork.refine.datasource.stats.Stats;
 import com.codefork.refine.resources.NameType;
 import com.codefork.refine.resources.Result;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
@@ -23,7 +22,6 @@ public class OrcidSmartNames extends OrcidBase {
     SmartNamesModeSearchQueryFactory smartNamesModeSearchQueryFactory =
             new SmartNamesModeSearchQueryFactory();
 
-    @Autowired
     public OrcidSmartNames(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
     }
@@ -51,12 +49,12 @@ public class OrcidSmartNames extends OrcidBase {
     }
 
     private List<Result> searchSmartNames(SearchQuery query, String givenName, String familyName) throws Exception {
-        String q = String.format("given-names:%s AND family-name:%s", givenName, familyName);
+        String q = "given-names:%s AND family-name:%s".formatted(givenName, familyName);
         String fields = createSearchFieldsQueryString(query);
         if(fields.length() > 0) {
             q += " " + fields;
         }
-        String url = String.format("https://pub.orcid.org/v2.1/search/?rows=%d&q=", query.getLimit()) +
+        String url = "https://pub.orcid.org/v2.1/search/?rows=%d&q=".formatted(query.getLimit()) +
                 UriUtils.encodeQueryParam(q, "UTF-8");
         return doSearch(query, url);
     }

--- a/src/main/java/com/codefork/refine/resources/NameType.java
+++ b/src/main/java/com/codefork/refine/resources/NameType.java
@@ -36,8 +36,7 @@ public class NameType {
 
     @Override
     public boolean equals(Object obj) {
-        if(obj instanceof NameType) {
-            NameType obj2 = (NameType) obj;
+        if(obj instanceof NameType obj2) {
             return obj2.getId().equals(getId())
                     && obj2.getName().equals(getName());
         }

--- a/src/main/java/com/codefork/refine/solr/AnotherSolr.java
+++ b/src/main/java/com/codefork/refine/solr/AnotherSolr.java
@@ -4,7 +4,6 @@ import com.codefork.refine.Config;
 import com.codefork.refine.ThreadPoolFactory;
 import com.codefork.refine.datasource.ConnectionFactory;
 import com.codefork.refine.datasource.stats.Stats;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +22,6 @@ import org.springframework.stereotype.Component;
 @Component("anothersolr")
 public class AnotherSolr extends Solr {
 
-    @Autowired
     public AnotherSolr(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
     }

--- a/src/main/java/com/codefork/refine/solr/Solr.java
+++ b/src/main/java/com/codefork/refine/solr/Solr.java
@@ -11,7 +11,6 @@ import com.codefork.refine.resources.Result;
 import com.codefork.refine.resources.ServiceMetaDataResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
@@ -42,7 +41,6 @@ public class Solr extends WebServiceDataSource {
 
     private SAXParserFactory spf = SAXParserFactory.newInstance();
 
-    @Autowired
     public Solr(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
     }
@@ -93,7 +91,7 @@ public class Solr extends WebServiceDataSource {
             log.error("Ignoring error from trying to close input stream and connection: " + ioe);
         }
 
-        log.debug(String.format("Query: %s - parsing took %dms, got %d results",
+        log.debug("Query: %s - parsing took %dms, got %d results".formatted(
                 query.getQuery(), parseTime, solrParser.getResults().size()));
 
         return solrParser.getResults();

--- a/src/main/java/com/codefork/refine/viaf/VIAF.java
+++ b/src/main/java/com/codefork/refine/viaf/VIAF.java
@@ -15,7 +15,6 @@ import com.codefork.refine.viaf.sources.NonVIAFSource;
 import com.codefork.refine.viaf.sources.Source;
 import com.codefork.refine.viaf.sources.VIAFSource;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriUtils;
@@ -47,7 +46,6 @@ public class VIAF extends WebServiceDataSource {
     private VIAFSource viafSource = null;
     private Map<String, NonVIAFSource> nonViafSources = new HashMap<>();
 
-    @Autowired
     public VIAF(Config config, CacheManager cacheManager, ThreadPoolFactory threadPoolFactory, ConnectionFactory connectionFactory, Stats stats) {
         super(config, cacheManager, threadPoolFactory, connectionFactory, stats);
 
@@ -102,14 +100,14 @@ public class VIAF extends WebServiceDataSource {
             }
             cqlTemplate = viafNameType.getCqlString();
         }
-        String cql = String.format(cqlTemplate, searchQuery.getQuery());
+        String cql = cqlTemplate.formatted(searchQuery.getQuery());
 
         // NOTE: this query means return all the name records that
         // have an entry for this source; it does NOT mean search the name
         // values for this source ONLY. I think.
         String source = searchQuery.getViafSource();
         if(source != null) {
-            cql += String.format(" and local.sources = \"%s\"", source.toLowerCase());
+            cql += " and local.sources = \"%s\"".formatted(source.toLowerCase());
         }
 
         return cql;
@@ -131,7 +129,7 @@ public class VIAF extends WebServiceDataSource {
             return Collections.emptyList();
         }
 
-        String url = String.format("https://www.viaf.org/viaf/search?query=%s&sortKeys=holdingscount&maximumRecords=%s",
+        String url = "https://www.viaf.org/viaf/search?query=%s&sortKeys=holdingscount&maximumRecords=%s".formatted(
                 UriUtils.encodeQueryParam(cql, "UTF-8"), query.getLimit());
 
         HttpURLConnection conn = getConnectionFactory().createConnection(url);
@@ -154,7 +152,7 @@ public class VIAF extends WebServiceDataSource {
         }
 
         List<Result> results = viafParser.getResults();
-        getLog().debug(String.format("Query: %s - parsing took %dms, got %d results",
+        getLog().debug("Query: %s - parsing took %dms, got %d results".formatted(
                 query.getQuery(), parseTime, results.size()));
 
         return results;

--- a/src/main/java/com/codefork/refine/viaf/VIAFProxyController.java
+++ b/src/main/java/com/codefork/refine/viaf/VIAFProxyController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 /**

--- a/src/main/java/com/codefork/refine/viaf/VIAFSourceSpecificController.java
+++ b/src/main/java/com/codefork/refine/viaf/VIAFSourceSpecificController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 /**

--- a/src/main/java/com/codefork/refine/viaf/sources/NonVIAFSource.java
+++ b/src/main/java/com/codefork/refine/viaf/sources/NonVIAFSource.java
@@ -69,7 +69,7 @@ public class NonVIAFSource extends Source {
             // which is NOT the case for several sources that don't have URL templates:
             // namely: BNC, BNF, DBC, NUKAT
             // Can't think of a way to fix this right now.
-            url = String.format("https://viaf.org/viaf/sourceID/%s|{{id}}", code);
+            url = "https://viaf.org/viaf/sourceID/%s|{{id}}".formatted(code);
         }
         return url;
     }

--- a/src/test/java/com/codefork/refine/viaf/VIAFParserTest.java
+++ b/src/test/java/com/codefork/refine/viaf/VIAFParserTest.java
@@ -58,7 +58,7 @@ public class VIAFParserTest {
         for(int i = 0; i < n; i++) {
             SAXParserFactory spf = SAXParserFactory.newInstance();
             SAXParser parser = spf.newSAXParser();
-            DefaultHandler viafParser = (DefaultHandler) parserClass.newInstance();
+            DefaultHandler viafParser = (DefaultHandler) parserClass.getDeclaredConstructor().newInstance();
 
             InputStream is = getClass().getResourceAsStream("/shakespeare.xml");
             long start = System.currentTimeMillis();
@@ -67,7 +67,7 @@ public class VIAFParserTest {
 
             times[i] = end - start;
         }
-        System.out.println(String.format("parse using %s, mean time over %s runs=%s", parserClass.toString(), n, mean(times)));
+        System.out.println("parse using %s, mean time over %s runs=%s".formatted(parserClass.toString(), n, mean(times)));
     }
 
     /*


### PR DESCRIPTION
Resolves #34.

Upgrades the project from Java 11 to **Java 21**, chaining the LTS steps and the Spring Boot upgrade Java 21 requires:
- Java 11 → 17 → 21 (compiler `release`, Dockerfile build + runtime images, JaCoCo 0.8.8 → 0.8.12 for Java-21 bytecode, maven-compiler-plugin 3.10.1 → 3.15.0)
- **Spring Boot 2.7.3 → 3.3.13** with the `javax` → `jakarta` namespace migration (via OpenRewrite `UpgradeSpringBoot_3_3`)

Verified locally: `mvn verify` is green under Temurin 21 — all 39 previously-passing tests still pass (no test lost).

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
